### PR TITLE
fix: 修复自动分组时标题丢失的问题

### DIFF
--- a/src/services/group.ts
+++ b/src/services/group.ts
@@ -17,7 +17,7 @@ export const group = async () => {
     const group: Record<string, number[]> = {};
     const other: number[] = [];
     tabs.forEach((tab) => {
-        if (!tab.url) {
+        if (!tab.id || !tab.url) {
             return;
         }
         if (fixedRegex && new RegExp(fixedRegex).test(tab.url)) {
@@ -34,7 +34,7 @@ export const group = async () => {
             const groupId = await chrome.tabs.group({
                 tabIds: group[name],
             });
-            chrome.tabGroups.update(groupId, {
+            await chrome.tabGroups.update(groupId, {
                 collapsed: true,
                 title: name,
             });
@@ -48,26 +48,28 @@ export const group = async () => {
         const fixedGroupId = await chrome.tabs.group({
             tabIds: fixed,
         });
-        chrome.tabGroups.update(fixedGroupId, {
+        await chrome.tabGroups.update(fixedGroupId, {
             collapsed: false,
             title: 'fixed',
             color: 'red',
         });
-        chrome.tabGroups.move(fixedGroupId, {
+        await chrome.tabGroups.move(fixedGroupId, {
             index: 1,
         });
     }
 
-    const otherGroupId = await chrome.tabs.group({
-        tabIds: other,
-    });
-    chrome.tabGroups.update(otherGroupId, {
-        collapsed: false,
-        title: '其他',
-    });
-    chrome.tabGroups.move(otherGroupId, {
-        index: -1,
-    });
+    if (other.length > 0) {
+        const otherGroupId = await chrome.tabs.group({
+            tabIds: other,
+        });
+        await chrome.tabGroups.update(otherGroupId, {
+            collapsed: false,
+            title: '其他',
+        });
+        await chrome.tabGroups.move(otherGroupId, {
+            index: -1,
+        });
+    }
 };
 
 export const ungroup = async () => {


### PR DESCRIPTION
### Motivation
- Recent Chrome behavior changes caused tab group metadata updates to be applied asynchronously, which made group titles disappear during automatic grouping; this change ensures metadata updates are applied reliably.

### Description
- Await `chrome.tabGroups.update` and `chrome.tabGroups.move` to guarantee updates complete before proceeding, ensuring titles and other metadata persist (`src/services/group.ts`).
- Skip creating the fallback "其他" group when there are no tabs to include to avoid unnecessary API calls (`src/services/group.ts`).
- Harden tab collection by ignoring tabs missing `id` or `url` to prevent invalid entries from breaking grouping (`src/services/group.ts`).

### Testing
- Ran `yarn lint` and it completed successfully.
- Ran `yarn build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a94f0b4f8c832db2b6122f1aa0935b)